### PR TITLE
mainthread.js : fix default sorting of posts

### DIFF
--- a/studips/src/component/MainThread.js
+++ b/studips/src/component/MainThread.js
@@ -104,7 +104,9 @@ class MainThread extends React.Component {
 			}))
 			
 		  default:
-			return (this.state.posts.map((post, i) => {
+			return (this.state.posts
+				.sort((a, b) => a.created_at > b.created_at ? -1 : 1)
+				.map((post, i) => {
 				return <PostCard postData={post} key={i} />
 			}))
 		}


### PR DESCRIPTION
This PR fix the default sorting of posts by date.